### PR TITLE
Declare local variable for not using free variable

### DIFF
--- a/gregorio-mode.el
+++ b/gregorio-mode.el
@@ -225,8 +225,7 @@ With a prefix argument, save buffer and execute gregorio on the buffer's file."
 	    (save-buffer)
 	    (shell-command
 	     (concat "gregorio " buffer-file-name) nil "*Gregorio Error*"))
-    (progn
-      (setf new-tex (concat (file-name-base) ".tex"))
+    (let ((new-tex (concat (file-name-base) ".tex")))
       (shell-command-on-region
        (point-min) (point-max)
        "gregorio -sS"


### PR DESCRIPTION
There are byte-compile warnings in original code.

```
In gregorio-to-tex:                                                               
gregorio-mode.el:233:8:Warning: assignment to free variable `new-tex'             
gregorio-mode.el:235:38:Warning: reference to free variable `new-tex'             
```